### PR TITLE
Add ParseDialogue tests

### DIFF
--- a/script_test.go
+++ b/script_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestParseDialogue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"newline", "Hello\nWorld", "Hello World"},
+		{"simple tag", "<b>Hello</b>", "Hello"},
+		{"tag with text", "<i>Hello</i> world", "Hello world"},
+		{"mixed", "<p>Hello\n<b>World</b></p>", "Hello World"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseDialogue(tt.input)
+			if got != tt.want {
+				t.Errorf("ParseDialogue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `script_test.go` to test `ParseDialogue`

## Testing
- `go test ./...` *(fails: go1.24.2 toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68431df5ac988332827e8d0b5470e33e