### PR TITLE
Fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module novegido
 
-go 1.24.2
+go 1.22
 
 require (
 	github.com/hajimehoshi/ebiten/v2 v2.8.8


### PR DESCRIPTION
## Summary
- set go version to 1.22 in go.mod

## Testing
- `go mod tidy` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68440604bac4833281dd3204e734943c