### PR TITLE
Enhance name box frame support

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,11 +90,11 @@ func (d DialogueBox) draw(screen *ebiten.Image, name, txt string) {
 		}
 
 		ntOp := &text.DrawOptions{}
-		ntOp.GeoM.Translate(float64(nameRect.Min.X+5), float64(nameRect.Min.Y+18))
+		ntOp.GeoM.Translate(float64(nameRect.Min.X+10), float64(nameRect.Max.Y-6))
 		ntOp.ColorScale.ScaleWithColor(color.White)
 		text.Draw(screen, name, uiFace, ntOp)
 
-		y += float64(nameHeight + 10)
+		y += float64(nameRect.Dy() + 10)
 	}
 
 	tOp := &text.DrawOptions{}


### PR DESCRIPTION
## Summary
- support framing the speaker name with a NineSlice
- offset speaker text relative to that frame

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: `Xrandr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684576bfb48c8332ad58deccc8da198b