### PR TITLE
Add headless tag for CI

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+//go:build !headless
+// +build !headless
+
 package main
 
 import (

--- a/renderer.go
+++ b/renderer.go
@@ -1,3 +1,6 @@
+//go:build !headless
+// +build !headless
+
 package main
 
 import (

--- a/script_test.go
+++ b/script_test.go
@@ -1,3 +1,6 @@
+//go:build headless
+// +build headless
+
 package main
 
 import (

--- a/ui.go
+++ b/ui.go
@@ -1,3 +1,6 @@
+//go:build !headless
+// +build !headless
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- add `headless` build tag to skip ebiten code when running tests
- mark tests to build only with the `headless` tag

## Testing
- `go test -tags=headless ./...`
- `go test ./...` *(fails: missing X11/ALSA headers)*

------
https://chatgpt.com/codex/tasks/task_e_6845a181e18c833298ba0de32df5ff9b