### PR TITLE
Inject UI component for font management

### DIFF
--- a/internal/ui/dialogue.go
+++ b/internal/ui/dialogue.go
@@ -6,29 +6,10 @@ package ui
 import (
 	"image"
 	"image/color"
-	"log"
-	"os"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 )
-
-// Face is the default font face used for UI text.
-var Face text.Face
-
-func init() {
-	f, err := os.Open("assets/fonts/DotGothic16-Regular.ttf")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
-
-	src, err := text.NewGoTextFaceSource(f)
-	if err != nil {
-		log.Fatal(err)
-	}
-	Face = &text.GoTextFace{Source: src, Size: 22}
-}
 
 // DialogueBox represents the main dialogue area.
 type DialogueBox struct {
@@ -38,7 +19,7 @@ type DialogueBox struct {
 }
 
 // Draw renders the dialogue box along with speaker name and text.
-func (d DialogueBox) Draw(screen *ebiten.Image, name, txt string) {
+func (d DialogueBox) Draw(screen *ebiten.Image, face text.Face, name, txt string) {
 	if d.Frame != nil {
 		d.Frame.Draw(screen, d.Rect)
 	} else {
@@ -72,7 +53,7 @@ func (d DialogueBox) Draw(screen *ebiten.Image, name, txt string) {
 		ntOp := &text.DrawOptions{}
 		ntOp.GeoM.Translate(float64(nameRect.Min.X+10), float64(nameRect.Max.Y-6))
 		ntOp.ColorScale.ScaleWithColor(color.White)
-		text.Draw(screen, name, Face, ntOp)
+		text.Draw(screen, name, face, ntOp)
 
 		y += float64(nameRect.Dy() + 10)
 	}
@@ -80,5 +61,5 @@ func (d DialogueBox) Draw(screen *ebiten.Image, name, txt string) {
 	tOp := &text.DrawOptions{}
 	tOp.GeoM.Translate(float64(d.Rect.Min.X+20), y)
 	tOp.ColorScale.ScaleWithColor(color.White)
-	text.Draw(screen, txt, Face, tOp)
+	text.Draw(screen, txt, face, tOp)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,30 @@
+//go:build !headless
+// +build !headless
+
+package ui
+
+import (
+	"os"
+
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+// UI holds assets used for rendering user interface elements.
+type UI struct {
+	Face text.Face
+}
+
+// New loads the default font and returns a UI object.
+func New() (*UI, error) {
+	f, err := os.Open("assets/fonts/DotGothic16-Regular.ttf")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	src, err := text.NewGoTextFaceSource(f)
+	if err != nil {
+		return nil, err
+	}
+	return &UI{Face: &text.GoTextFace{Source: src, Size: 22}}, nil
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"novegido/internal/game"
 	"novegido/internal/script"
+	"novegido/internal/ui"
 )
 
 var (
@@ -26,7 +27,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	g := game.NewGame(pages, *screenWidth, *screenHeight)
+	uiObj, err := ui.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	g := game.NewGame(uiObj, pages, *screenWidth, *screenHeight)
 	ebiten.SetWindowSize(*screenWidth, *screenHeight)
 	ebiten.SetWindowTitle("Novel Game Demo")
 	if err := ebiten.RunGame(g); err != nil {


### PR DESCRIPTION
## Summary
- load font in a new `ui.UI` struct instead of a global
- update `DialogueBox.Draw` to take a font face
- inject the UI component into `Game`
- construct the UI in `main`

## Testing
- `go test ./...` *(fails: X11/alsa build requirements missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846dea642088332a0fbc5ea25e88998